### PR TITLE
Fix `--warning/-w` argument being ignored

### DIFF
--- a/check_aws_ec2_backup
+++ b/check_aws_ec2_backup
@@ -78,7 +78,7 @@ while test $# -ne 0; do
     -r|--region) REGION=$1; shift ;;
     -v|--volume-id) VOLUME_ID=$1; shift ;;
     -p|--profile) PROFILE=$1; shift ;;
-    -w|--warning) WARNING_STATES=$1; shift ;;
+    -w|--warning) WARNING_THRESHOLD=$1; shift ;;
     -c|--critical) CRITICAL_THRESHOLD=$1; shift ;;
     -a|--aws-cli-path) AWS_CLI_BIN_PATH=$1; shift ;;
     -V|--version) version; exit ;;

--- a/test/check_aws_ec2_backup.bats
+++ b/test/check_aws_ec2_backup.bats
@@ -234,29 +234,29 @@ load 'test_helper'
 # --warning
 # ------------------------------------------------------------------------------
 @test "--warning overrides default" {
-  SNAPSHOT_DATETIME_25_HOURS_AGO="$(date -u -d '-25 hours' $AWS_DATE_FORMAT)"
-  AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_25_HOURS_AGO}"
+  SNAPSHOT_DATETIME_2_HOURS_AGO="$(date -u -d '-2 hours' $AWS_DATE_FORMAT)"
+  AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_2_HOURS_AGO}"
   stub aws \
     "configure list" \
     "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
-  run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo --warning 129600
+  run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo --warning 3600
 
   assert_failure 1
-  assert_output "WARNING: Snapshot created ${SNAPSHOT_DATETIME_25_HOURS_AGO}"
+  assert_output "WARNING: Snapshot created ${SNAPSHOT_DATETIME_2_HOURS_AGO}"
 }
 
 @test "-w is an alias for --warning" {
-  SNAPSHOT_DATETIME_25_HOURS_AGO="$(date -u -d '-25 hours' $AWS_DATE_FORMAT)"
-  AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_25_HOURS_AGO}"
+  SNAPSHOT_DATETIME_2_HOURS_AGO="$(date -u -d '-2 hours' $AWS_DATE_FORMAT)"
+  AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_2_HOURS_AGO}"
   stub aws \
     "configure list" \
     "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
-  run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo -w 129600
+  run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo -w 3600
 
   assert_failure 1
-  assert_output "WARNING: Snapshot created ${SNAPSHOT_DATETIME_25_HOURS_AGO}"
+  assert_output "WARNING: Snapshot created ${SNAPSHOT_DATETIME_2_HOURS_AGO}"
 }
 
 # --aws-cli-path


### PR DESCRIPTION
#### Because:

* The argument parsing was not correctly overridding the default.

#### This change:

* Sets the WARNING threshold correctly.
* Fixes the tests. This wasn't caught because the tests were increasing
  the WARNING threshold to 25hrs instead of decreasing it - so the
  default was still returning a warning instead of an OK.