### PR TITLE
Ignore snapshots with status 'error'

### DIFF
--- a/check_aws_ec2_backup
+++ b/check_aws_ec2_backup
@@ -144,7 +144,7 @@ if [ -z "$VOLUME_ID" ]; then
 fi
 
 # fetch the most recent snapshot time for the volume ID
-SNAPSHOTS="$($AWS_CLI_BIN_PATH ec2 describe-snapshots $PROFILE_ARG --region $REGION --filters Name=volume-id,Values=$VOLUME_ID --output text --query Snapshots[*].{Time:StartTime} 2>&1)"
+SNAPSHOTS="$($AWS_CLI_BIN_PATH ec2 describe-snapshots $PROFILE_ARG --region $REGION --filters Name=volume-id,Values=$VOLUME_ID Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} 2>&1)"
 
 if [ $? -ne 0 ]; then
   echo 'UNKNOWN: Unable to fetch snapshots via AWS CLI'

--- a/test/check_aws_ec2_backup.bats
+++ b/test/check_aws_ec2_backup.bats
@@ -86,7 +86,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_24_HOURS_AGO}\n${SNAPSHOT_DATETIME_99_HOURS_AGO}"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo
 
@@ -100,7 +100,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_25_HOURS_AGO}\n${SNAPSHOT_DATETIME_99_HOURS_AGO}"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo
 
@@ -113,7 +113,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_99_HOURS_AGO}"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo
 
@@ -125,7 +125,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE=""
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo
 
@@ -146,7 +146,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="$(date -u $AWS_DATE_FORMAT)"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --region us-east-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --region us-east-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup -r us-east-1 --volume-id foo
 
@@ -160,7 +160,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="$(date -u $AWS_DATE_FORMAT)"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=bar --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=bar Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id bar
 
@@ -174,7 +174,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="$(date -u $AWS_DATE_FORMAT)"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --profile foo-profile --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --profile foo-profile --region eu-west-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo --profile foo-profile
 
@@ -186,7 +186,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="$(date -u $AWS_DATE_FORMAT)"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --profile foo-profile --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --profile foo-profile --region eu-west-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo -p foo-profile
 
@@ -201,7 +201,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_2_HOURS_AGO}"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo --critical 3600
 
@@ -214,7 +214,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_99_HOURS_AGO}"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo --critical 604800
 
@@ -227,7 +227,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_99_HOURS_AGO}"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo -c 604800
 
@@ -242,7 +242,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_2_HOURS_AGO}"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo --warning 3600
 
@@ -255,7 +255,7 @@ load 'test_helper'
   AWS_CLI_RESPONSE="${SNAPSHOT_DATETIME_2_HOURS_AGO}"
   stub aws \
     "configure list" \
-    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
+    "ec2 describe-snapshots --region eu-west-1 --filters Name=volume-id,Values=foo Name=status,Values=pending,completed --output text --query Snapshots[*].{Time:StartTime} : echo -e '${AWS_CLI_RESPONSE}'"
 
   run $BASE_DIR/check_aws_ec2_backup --region eu-west-1 --volume-id foo -w 3600
 


### PR DESCRIPTION
#### Because:

* AWS EBS Snapshots can have 3 states; `pending`, `completed` & `error`.
  http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-snapshots.html
* If a snapshot has errored then it likely cannot be restored from, so
  is not a valid backup and should be ignored.

#### This change:

* Uses AWS CLI `describe-snapshots`'s `--filters` argument to filter out
  any snapshots that are not `pending` or `completed`.

#### Notes:

* Keeping `pending` for now, as it's difficult to know how long
  snapshots may take for different users - which could cause a flapping
  check.